### PR TITLE
Material-ui start; button and navbar

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,8 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
+    "@material-ui/core": "^3.5.1",
+    "@material-ui/icons": "^3.0.1",
     "apollo-cache-inmemory": "^1.3.9",
     "apollo-client": "^2.4.5",
     "apollo-link": "^1.2.3",
@@ -11,6 +13,7 @@
     "cross-env": "^5.2.0",
     "graphql": "^14.0.2",
     "graphql-tag": "^2.10.0",
+    "prop-types": "^15.6.2",
     "react": "^16.5.2",
     "react-apollo": "^2.2.4",
     "react-dom": "^16.5.2",

--- a/src/Components/App/index.js
+++ b/src/Components/App/index.js
@@ -30,7 +30,7 @@ export default class App extends Component {
           <AuthRequired>
             <Switch>
               <Route path="/login" component={ Login } />
-              <Route component={ ProductRegistration } />
+              <Route path="/product/register" component={ ProductRegistration } />
               <Route component={ Welcome } />
             </Switch>
           </AuthRequired>

--- a/src/Components/App/index.js
+++ b/src/Components/App/index.js
@@ -1,25 +1,40 @@
 import React, { Component } from 'react';
 import { Route, Switch } from 'react-router-dom';
+import { createMuiTheme, MuiThemeProvider } from '@material-ui/core';
 import AuthRequired from '../AuthRequired';
 import Login from '../Login';
 import Navbar from '../Navbar';
 import Welcome from '../Welcome';
 import ProductRegistration from '../ProductRegistration';
-
 import './App.css';
+
+const theme = createMuiTheme({
+  // because we apparently use typography and it will be deprecated with the next release,
+  // to have a smooth transition:
+  typography: {
+    useNextVariants: true,
+  },
+  palette: {
+    primary: {
+      main: '#0a45c1',
+    },
+  },
+});
 
 export default class App extends Component {
   render() {
     return (
       <>
-        <Navbar />
-        <AuthRequired>
-          <Switch>
-            <Route path="/login" component={ Login } />
-            <Route path="/product/register" component={ ProductRegistration } />
-            <Route component={ Welcome } />
-          </Switch>
-        </AuthRequired>
+        <MuiThemeProvider theme={theme}>
+          <Navbar />
+          <AuthRequired>
+            <Switch>
+              <Route path="/login" component={ Login } />
+              <Route component={ ProductRegistration } />
+              <Route component={ Welcome } />
+            </Switch>
+          </AuthRequired>
+        </MuiThemeProvider>
       </>
     );
   }

--- a/src/Components/Login/index.js
+++ b/src/Components/Login/index.js
@@ -2,20 +2,6 @@ import React, { Component } from 'react';
 import { withRouter } from 'react-router-dom';
 import './login.css';
 import Button from '@material-ui/core/Button';
-import { createMuiTheme, MuiThemeProvider } from '@material-ui/core';
-
-const theme = createMuiTheme({
-  // because we apparently use typography and it will be deprecated with the next release,
-  // to have a smooth transition:
-  typography: {
-    useNextVariants: true,
-  },
-  palette: {
-    primary: {
-      main: '#0a45c1',
-    },
-  },
-});
 
 @withRouter
 export default class Login extends Component {
@@ -75,11 +61,9 @@ export default class Login extends Component {
                       </td>
                       <td>
                         <br />
-                        <MuiThemeProvider theme={theme}>
-                          <Button variant="contained" color="primary" onClick={this.onSubmit}>
+                        <Button variant="contained" color="primary" onClick={this.onSubmit}>
                             Log in
-                          </Button>
-                        </MuiThemeProvider>
+                        </Button>
                       </td>
                     </tr>
                   </tbody>

--- a/src/Components/Login/index.js
+++ b/src/Components/Login/index.js
@@ -1,6 +1,21 @@
 import React, { Component } from 'react';
 import { withRouter } from 'react-router-dom';
 import './login.css';
+import Button from '@material-ui/core/Button';
+import { createMuiTheme, MuiThemeProvider } from '@material-ui/core';
+
+const theme = createMuiTheme({
+  // because we apparently use typography and it will be deprecated with the next release,
+  // to have a smooth transition:
+  typography: {
+    useNextVariants: true,
+  },
+  palette: {
+    primary: {
+      main: '#0a45c1',
+    },
+  },
+});
 
 @withRouter
 export default class Login extends Component {
@@ -60,8 +75,11 @@ export default class Login extends Component {
                       </td>
                       <td>
                         <br />
-                        <input type="submit" className="ok" value="Log in"
-                          onClick={this.onSubmit} />
+                        <MuiThemeProvider theme={theme}>
+                          <Button variant="contained" color="primary" onClick={this.onSubmit}>
+                            Log in
+                          </Button>
+                        </MuiThemeProvider>
                       </td>
                     </tr>
                   </tbody>

--- a/src/Components/Navbar/index.js
+++ b/src/Components/Navbar/index.js
@@ -14,7 +14,6 @@ import { Route, Switch, withRouter } from 'react-router-dom';
 import QueryHOC from '../HOC/QueryHOC';
 import client from '../../apollo';
 
-
 const query = gql`{
   users {
     firstName

--- a/src/Components/Navbar/index.js
+++ b/src/Components/Navbar/index.js
@@ -1,8 +1,19 @@
 import React, { Component } from 'react';
 import './navbar.css';
+import { MuiThemeProvider, createMuiTheme } from '@material-ui/core/styles';
+import AppBar from '@material-ui/core/AppBar';
+import Toolbar from '@material-ui/core/Toolbar';
+import Typography from '@material-ui/core/Typography';
+import IconButton from '@material-ui/core/IconButton';
+import MenuIcon from '@material-ui/icons/Menu';
+import AccountCircle from '@material-ui/icons/AccountCircle';
+import MenuItem from '@material-ui/core/MenuItem';
+import Menu from '@material-ui/core/Menu';
 import gql from 'graphql-tag';
-import { Route, Switch } from 'react-router-dom';
+import { Route, Switch, withRouter } from 'react-router-dom';
 import QueryHOC from '../HOC/QueryHOC';
+import client from '../../apollo';
+
 
 const query = gql`{
   users {
@@ -10,29 +21,116 @@ const query = gql`{
   }
 }`;
 
-@QueryHOC(query)
-class UserMessage extends Component {
-  render() {
-    const { loading, error, data } = this.props.queryResults;
-    if (loading) return 'Gegevens worden geladen..';
-    if (error) return '';
-    const user = data.users[0];
-    return (
-      <div>
-        Welkom, {user.firstName}
-      </div>
-    );
-  }
-}
-
 export default class Navbar extends Component {
   render() {
     return (
       <div className="navbar">
         <Switch>
           <Route path="/login" render={() => 'Login'} />
-          <Route path="/" component={UserMessage} />
+          <Route path="/" component={NavbarContent} />
         </Switch>
+      </div>
+    );
+  }
+}
+
+const theme = createMuiTheme({
+  // because we apparently use typography and it will be deprecated with the next release,
+  // to have a smooth transition:
+  typography: {
+    useNextVariants: true,
+  },
+  palette: {
+    primary: {
+      // light: will be calculated from palette.primary.main,
+      main: '#0a45c1',
+      // dark: will be calculated from palette.primary.main,
+      // contrastText: will be calculated to contrast with palette.primary.main
+    },
+  },
+});
+
+@QueryHOC(query)
+@withRouter
+export class NavbarContent extends Component {
+  state = {
+    auth: true,
+    anchorEl: null,
+  };
+
+  logout = this.logout.bind(this);
+
+  logout() {
+    localStorage.clear();
+    client.resetStore();
+    this.props.history.push('/login');
+  }
+
+  handleMenu = (event) => {
+    this.setState({ anchorEl: event.currentTarget });
+  };
+
+  handleClose = () => {
+    this.setState({ anchorEl: null });
+  };
+
+  render() {
+    const { anchorEl } = this.state;
+    const open = Boolean(anchorEl);
+    const { loading, error, data } = this.props.queryResults;
+    if (loading) return 'Gegevens worden geladen..';
+    if (error) return 'Er ging iets fout';
+    const user = data.users[0];
+
+    return (
+      <div className='navbar'>
+        <MuiThemeProvider theme={theme}>
+          <AppBar position="static">
+            <Toolbar>
+              <Typography variant="h6" color="inherit" className='typography'>
+                Welkom, {user.firstName}
+              </Typography>
+              <div className='menuRight'>
+                <div>
+                  <IconButton
+                    className='button'
+                    color="inherit"
+                    aria-label="Menu"
+                  >
+                    <MenuIcon />
+                  </IconButton>
+                </div>
+                <div>
+                  <IconButton
+                    aria-owns={open ? 'menu-appbaraccount' : undefined}
+                    aria-haspopup="true"
+                    onClick={this.handleMenu}
+                    color="inherit"
+                  >
+                    <AccountCircle />
+                  </IconButton>
+                  <Menu
+                    id="menu-appbaraccount"
+                    anchorEl={anchorEl}
+                    anchorOrigin={{
+                      vertical: 'top',
+                      horizontal: 'right',
+                    }}
+                    transformOrigin={{
+                      vertical: 'top',
+                      horizontal: 'right',
+                    }}
+                    open={open}
+                    onClose={this.handleClose}
+                  >
+                    <MenuItem onClick={this.handleClose}>Account</MenuItem>
+                    <MenuItem onClick={this.logout}>Log uit</MenuItem>
+                  </Menu>
+                </div>
+              </div>
+            </Toolbar>
+          </AppBar>
+        </MuiThemeProvider>
       </div>
     );
   }

--- a/src/Components/Navbar/index.js
+++ b/src/Components/Navbar/index.js
@@ -1,6 +1,5 @@
 import React, { Component } from 'react';
 import './navbar.css';
-import { MuiThemeProvider, createMuiTheme } from '@material-ui/core/styles';
 import AppBar from '@material-ui/core/AppBar';
 import Toolbar from '@material-ui/core/Toolbar';
 import Typography from '@material-ui/core/Typography';
@@ -32,22 +31,6 @@ export default class Navbar extends Component {
     );
   }
 }
-
-const theme = createMuiTheme({
-  // because we apparently use typography and it will be deprecated with the next release,
-  // to have a smooth transition:
-  typography: {
-    useNextVariants: true,
-  },
-  palette: {
-    primary: {
-      // light: will be calculated from palette.primary.main,
-      main: '#0a45c1',
-      // dark: will be calculated from palette.primary.main,
-      // contrastText: will be calculated to contrast with palette.primary.main
-    },
-  },
-});
 
 @QueryHOC(query)
 @withRouter
@@ -83,53 +66,51 @@ export class NavbarContent extends Component {
 
     return (
       <div className='navbar'>
-        <MuiThemeProvider theme={theme}>
-          <AppBar position="static">
-            <Toolbar>
-              <Typography variant="h6" color="inherit" className='typography'>
+        <AppBar position="static">
+          <Toolbar>
+            <Typography variant="h6" color="inherit" className='typography'>
                 Welkom, {user.firstName}
-              </Typography>
-              <div className='menuRight'>
-                <div>
-                  <IconButton
-                    className='button'
-                    color="inherit"
-                    aria-label="Menu"
-                  >
-                    <MenuIcon />
-                  </IconButton>
-                </div>
-                <div>
-                  <IconButton
-                    aria-owns={open ? 'menu-appbaraccount' : undefined}
-                    aria-haspopup="true"
-                    onClick={this.handleMenu}
-                    color="inherit"
-                  >
-                    <AccountCircle />
-                  </IconButton>
-                  <Menu
-                    id="menu-appbaraccount"
-                    anchorEl={anchorEl}
-                    anchorOrigin={{
-                      vertical: 'top',
-                      horizontal: 'right',
-                    }}
-                    transformOrigin={{
-                      vertical: 'top',
-                      horizontal: 'right',
-                    }}
-                    open={open}
-                    onClose={this.handleClose}
-                  >
-                    <MenuItem onClick={this.handleClose}>Account</MenuItem>
-                    <MenuItem onClick={this.logout}>Log uit</MenuItem>
-                  </Menu>
-                </div>
+            </Typography>
+            <div className='menuRight'>
+              <div>
+                <IconButton
+                  className='button'
+                  color="inherit"
+                  aria-label="Menu"
+                >
+                  <MenuIcon />
+                </IconButton>
               </div>
-            </Toolbar>
-          </AppBar>
-        </MuiThemeProvider>
+              <div>
+                <IconButton
+                  aria-owns={open ? 'menu-appbaraccount' : undefined}
+                  aria-haspopup="true"
+                  onClick={this.handleMenu}
+                  color="inherit"
+                >
+                  <AccountCircle />
+                </IconButton>
+                <Menu
+                  id="menu-appbaraccount"
+                  anchorEl={anchorEl}
+                  anchorOrigin={{
+                    vertical: 'top',
+                    horizontal: 'right',
+                  }}
+                  transformOrigin={{
+                    vertical: 'top',
+                    horizontal: 'right',
+                  }}
+                  open={open}
+                  onClose={this.handleClose}
+                >
+                  <MenuItem onClick={this.handleClose}>Account</MenuItem>
+                  <MenuItem onClick={this.logout}>Log uit</MenuItem>
+                </Menu>
+              </div>
+            </div>
+          </Toolbar>
+        </AppBar>
       </div>
     );
   }

--- a/src/Components/Navbar/navbar.css
+++ b/src/Components/Navbar/navbar.css
@@ -1,9 +1,6 @@
-.navbar {
-  height: 50px;
-  color: white;
-  text-align: center;
-  font-size: 2rem;
-  padding-top: 15px;
-  background-color: #0a45c1;
-  font-weight: bold;
+.menuRight {
+  display: flex;
+  align-content: flex-start;
+  justify-content: flex-start;
+  margin-left: auto;
 }

--- a/src/Components/ProductRegistration/index.js
+++ b/src/Components/ProductRegistration/index.js
@@ -2,7 +2,9 @@ import React, { Component } from 'react';
 import { withRouter } from 'react-router-dom';
 import gql from 'graphql-tag';
 import './productregistration.css';
-import Table from '../Table';
+import Button from '@material-ui/core/Button';
+import AddIcon from '@material-ui/icons/Add';
+import { createMuiTheme, MuiThemeProvider } from '@material-ui/core';
 import QueryHOC from '../HOC/QueryHOC';
 
 const query = gql`{
@@ -10,6 +12,19 @@ const query = gql`{
     name code locations {code} recommended_stock 
   }
 }`;
+
+const theme = createMuiTheme({
+  // because we apparently use typography and it will be deprecated with the next release,
+  // to have a smooth transition:
+  typography: {
+    useNextVariants: true,
+  },
+  palette: {
+    primary: {
+      main: '#0a45c1',
+    },
+  },
+});
 
 const columnFormatting = ['name', 'code', ({ locations }) => locations.reduce((accum, { code }) => `${accum}, ${code}`, '').substring(2), 'recommended_stock'];
 const firstRowTable = ['Product', 'Type', 'Locatie', 'Aanbevolen voorraad'];
@@ -29,6 +44,11 @@ export default class ProductRegistration extends Component {
           <h3>
             Huidige producten:
           </h3>
+          <MuiThemeProvider theme={theme}>
+            <Button variant='fab' color='primary' className='add' onClick={this.handleClickOpen}>
+              <AddIcon />
+            </Button>
+          </MuiThemeProvider>
         </div>
         <Table data = {data.items} headers = {firstRowTable} columns = {columnFormatting}/>
       </div>

--- a/src/Components/ProductRegistration/index.js
+++ b/src/Components/ProductRegistration/index.js
@@ -4,7 +4,6 @@ import gql from 'graphql-tag';
 import './productregistration.css';
 import Button from '@material-ui/core/Button';
 import AddIcon from '@material-ui/icons/Add';
-import { createMuiTheme, MuiThemeProvider } from '@material-ui/core';
 import Dialog from '@material-ui/core/Dialog/Dialog';
 import DialogTitle from '@material-ui/core/DialogTitle/DialogTitle';
 import DialogContent from '@material-ui/core/DialogContent/DialogContent';
@@ -18,19 +17,6 @@ const query = gql`{
     name code locations {code} recommended_stock 
   }
 }`;
-
-const theme = createMuiTheme({
-  // because we apparently use typography and it will be deprecated with the next release,
-  // to have a smooth transition:
-  typography: {
-    useNextVariants: true,
-  },
-  palette: {
-    primary: {
-      main: '#0a45c1',
-    },
-  },
-});
 
 const columnFormatting = ['name', 'code', ({ locations }) => locations.reduce((accum, { code }) => `${accum}, ${code}`, '').substring(2), 'recommended_stock'];
 const firstRowTable = ['Product', 'Type', 'Locatie', 'Aanbevolen voorraad'];
@@ -64,56 +50,54 @@ export default class ProductRegistration extends Component {
           <h3>
             Huidige producten:
           </h3>
-          <MuiThemeProvider theme={theme}>
-            <Button variant='fab' color='primary' className='add' onClick={this.handleClickOpen}>
-              <AddIcon />
-            </Button>
-            <Dialog
-              className='dialogueWindow'
-              open={this.state.open}
-              onClose={this.handleClose}
-              aria-labelledby='alert-dialog-title'
-              aria-describedby='alert-dialog-description'
-            >
-              <DialogTitle id='alert-dialog-title'>Voeg een product toe:</DialogTitle>
-              <DialogContent className='dialogueContent'>
-                <div>
-                  <TextField
-                    id='standard-name'
-                    label='Product'
-                    margin='normal'
-                  />
-                </div>
-                <div>
-                  <TextField
-                    id='standard-name'
-                    label='Type'
-                    margin='normal'
-                  />
-                </div>
+          <Button variant='fab' color='primary' className='add' onClick={this.handleClickOpen}>
+            <AddIcon />
+          </Button>
+          <Dialog
+            className='dialogueWindow'
+            open={this.state.open}
+            onClose={this.handleClose}
+            aria-labelledby='alert-dialog-title'
+            aria-describedby='alert-dialog-description'
+          >
+            <DialogTitle id='alert-dialog-title'>Voeg een product toe:</DialogTitle>
+            <DialogContent className='dialogueContent'>
+              <div>
                 <TextField
                   id='standard-name'
-                  label='Locatie'
+                  label='Product'
                   margin='normal'
                 />
-                <div>
-                  <TextField
-                    id='standard-name'
-                    label='Aanbevolen voorraad'
-                    margin='normal'
-                  />
-                </div>
-              </DialogContent>
-              <DialogActions>
-                <Button onClick={this.handleClose} color="primary">
+              </div>
+              <div>
+                <TextField
+                  id='standard-name'
+                  label='Type'
+                  margin='normal'
+                />
+              </div>
+              <TextField
+                id='standard-name'
+                label='Locatie'
+                margin='normal'
+              />
+              <div>
+                <TextField
+                  id='standard-name'
+                  label='Aanbevolen voorraad'
+                  margin='normal'
+                />
+              </div>
+            </DialogContent>
+            <DialogActions>
+              <Button onClick={this.handleClose} color="primary">
                   Cancel
-                </Button>
-                <Button onClick={this.handleClose} color="primary" autoFocus>
+              </Button>
+              <Button onClick={this.handleClose} color="primary" autoFocus>
                   Ok
-                </Button>
-              </DialogActions>
-            </Dialog>
-          </MuiThemeProvider>
+              </Button>
+            </DialogActions>
+          </Dialog>
         </div>
         <Table data = {data.items} headers = {firstRowTable} columns = {columnFormatting}/>
       </div>

--- a/src/Components/ProductRegistration/index.js
+++ b/src/Components/ProductRegistration/index.js
@@ -60,7 +60,7 @@ export default class ProductRegistration extends Component {
       return 'Something went wrong';
     }
     return (
-      <div className = "register">
+      <div className = 'register'>
         <div className='header'>
           <h3>
             Huidige producten:

--- a/src/Components/ProductRegistration/index.js
+++ b/src/Components/ProductRegistration/index.js
@@ -8,7 +8,6 @@ import { createMuiTheme, MuiThemeProvider } from '@material-ui/core';
 import Dialog from '@material-ui/core/Dialog/Dialog';
 import DialogTitle from '@material-ui/core/DialogTitle/DialogTitle';
 import DialogContent from '@material-ui/core/DialogContent/DialogContent';
-import DialogContentText from '@material-ui/core/DialogContentText/DialogContentText';
 import DialogActions from '@material-ui/core/DialogActions/DialogActions';
 import TextField from '@material-ui/core/TextField';
 import QueryHOC from '../HOC/QueryHOC';

--- a/src/Components/ProductRegistration/index.js
+++ b/src/Components/ProductRegistration/index.js
@@ -70,41 +70,40 @@ export default class ProductRegistration extends Component {
               <AddIcon />
             </Button>
             <Dialog
+              className='dialogueWindow'
               open={this.state.open}
               onClose={this.handleClose}
               aria-labelledby='alert-dialog-title'
               aria-describedby='alert-dialog-description'
             >
               <DialogTitle id='alert-dialog-title'>Voeg een product toe:</DialogTitle>
-              <DialogContent>
-                <DialogContentText id='alert-dialog-description'>
+              <DialogContent className='dialogueContent'>
+                <div>
                   <TextField
                     id='standard-name'
                     label='Product'
                     margin='normal'
                   />
-                </DialogContentText>
-                <DialogContentText id='alert-dialog-description'>
+                </div>
+                <div>
                   <TextField
                     id='standard-name'
                     label='Type'
                     margin='normal'
                   />
-                  <DialogContentText id='alert-dialog-description'>
-                  </DialogContentText>
-                  <TextField
-                    id='standard-name'
-                    label='Locatie'
-                    margin='normal'
-                  />
-                  <DialogContentText id='alert-dialog-description'>
-                  </DialogContentText>
+                </div>
+                <TextField
+                  id='standard-name'
+                  label='Locatie'
+                  margin='normal'
+                />
+                <div>
                   <TextField
                     id='standard-name'
                     label='Aanbevolen voorraad'
                     margin='normal'
                   />
-                </DialogContentText>
+                </div>
               </DialogContent>
               <DialogActions>
                 <Button onClick={this.handleClose} color="primary">

--- a/src/Components/ProductRegistration/index.js
+++ b/src/Components/ProductRegistration/index.js
@@ -5,7 +5,14 @@ import './productregistration.css';
 import Button from '@material-ui/core/Button';
 import AddIcon from '@material-ui/icons/Add';
 import { createMuiTheme, MuiThemeProvider } from '@material-ui/core';
+import Dialog from '@material-ui/core/Dialog/Dialog';
+import DialogTitle from '@material-ui/core/DialogTitle/DialogTitle';
+import DialogContent from '@material-ui/core/DialogContent/DialogContent';
+import DialogContentText from '@material-ui/core/DialogContentText/DialogContentText';
+import DialogActions from '@material-ui/core/DialogActions/DialogActions';
+import TextField from '@material-ui/core/TextField';
 import QueryHOC from '../HOC/QueryHOC';
+import Table from '../Table';
 
 const query = gql`{
   items {
@@ -32,6 +39,20 @@ const firstRowTable = ['Product', 'Type', 'Locatie', 'Aanbevolen voorraad'];
 @QueryHOC(query)
 @withRouter
 export default class ProductRegistration extends Component {
+  state = {
+    open: false,
+  };
+
+  handleClickOpen = () => {
+    this.setState({
+      open: true,
+    });
+  };
+
+  handleClose = () => {
+    this.setState({ open: false });
+  };
+
   render() {
     const { loading, error, data } = this.props.queryResults;
     if (loading) return 'Loading graphql query..';
@@ -48,6 +69,52 @@ export default class ProductRegistration extends Component {
             <Button variant='fab' color='primary' className='add' onClick={this.handleClickOpen}>
               <AddIcon />
             </Button>
+            <Dialog
+              open={this.state.open}
+              onClose={this.handleClose}
+              aria-labelledby='alert-dialog-title'
+              aria-describedby='alert-dialog-description'
+            >
+              <DialogTitle id='alert-dialog-title'>Voeg een product toe:</DialogTitle>
+              <DialogContent>
+                <DialogContentText id='alert-dialog-description'>
+                  <TextField
+                    id='standard-name'
+                    label='Product'
+                    margin='normal'
+                  />
+                </DialogContentText>
+                <DialogContentText id='alert-dialog-description'>
+                  <TextField
+                    id='standard-name'
+                    label='Type'
+                    margin='normal'
+                  />
+                  <DialogContentText id='alert-dialog-description'>
+                  </DialogContentText>
+                  <TextField
+                    id='standard-name'
+                    label='Locatie'
+                    margin='normal'
+                  />
+                  <DialogContentText id='alert-dialog-description'>
+                  </DialogContentText>
+                  <TextField
+                    id='standard-name'
+                    label='Aanbevolen voorraad'
+                    margin='normal'
+                  />
+                </DialogContentText>
+              </DialogContent>
+              <DialogActions>
+                <Button onClick={this.handleClose} color="primary">
+                  Cancel
+                </Button>
+                <Button onClick={this.handleClose} color="primary" autoFocus>
+                  Ok
+                </Button>
+              </DialogActions>
+            </Dialog>
           </MuiThemeProvider>
         </div>
         <Table data = {data.items} headers = {firstRowTable} columns = {columnFormatting}/>

--- a/src/Components/ProductRegistration/productregistration.css
+++ b/src/Components/ProductRegistration/productregistration.css
@@ -6,3 +6,12 @@
   justify-content: space-between;
   width: 830px;
 }
+
+.dialogueWindow {
+  height: 700px;
+}
+
+.dialogueContent {
+  display: flex;
+  flex-direction: column;
+}

--- a/src/Components/ProductRegistration/productregistration.css
+++ b/src/Components/ProductRegistration/productregistration.css
@@ -1,4 +1,8 @@
 .header {
   margin-left: 5%;
   margin-top: 5%;
+  display: flex;
+  flex-direction: row;
+  justify-content: space-between;
+  width: 830px;
 }

--- a/src/Components/Welcome/index.js
+++ b/src/Components/Welcome/index.js
@@ -51,10 +51,6 @@ export default class Welcome extends Component {
               <td> Rollen: </td>
               <td><ul>{user.roles.map(userToJSX)}</ul></td>
             </tr>
-            <tr>
-              <td></td>
-              <td className="lastcell"><input type="submit" className="logout" value="Logout" onClick={this.logout} /></td>
-            </tr>
           </tbody>
         </table>
       </div>


### PR DESCRIPTION
Heb de navbar als et goed is omgezet naar een material-ui navbar.
Je kan nu uitloggen via de navbar, maar verder doet ie nog net zo weinig als de vorige.
Ziet er zo uit:
<img width="1364" alt="screen shot 2018-11-25 at 20 49 23" src="https://user-images.githubusercontent.com/23311732/48983790-a4f46780-f0f3-11e8-90b5-fa200aa33a75.png">
<img width="1366" alt="screen shot 2018-11-25 at 20 49 12" src="https://user-images.githubusercontent.com/23311732/48983796-b3db1a00-f0f3-11e8-90e0-86c9233e611b.png">
Een dingetje.. Ik krijg de navbar niet boven de login en I dont know why, as in volgens mij heb ik em precies zo gemaakt als ie daarvoor was, maar obviously niet..
Zo ziet et er nu uit als je uitlogt:
<img width="1361" alt="screen shot 2018-11-25 at 20 48 29" src="https://user-images.githubusercontent.com/23311732/48983784-81c9b800-f0f3-11e8-9cb8-c28191944767.png">
 
ProductRegistration pagina ziet er nu zo uit:
<img width="1368" alt="screen shot 2018-11-26 at 23 27 33" src="https://user-images.githubusercontent.com/23311732/49046163-7ea5f900-f1d3-11e8-802c-2fcaf7ab4f5a.png">

